### PR TITLE
Verify downloaded sources and use Jessie

### DIFF
--- a/0.9/Dockerfile
+++ b/0.9/Dockerfile
@@ -1,11 +1,17 @@
-FROM debian:wheezy
+FROM debian:weezy
 MAINTAINER Adam Hawkins <adam@hawkins.io>
 
 ENV THRIFT_VERSION 0.9.3
 
+# Thrift '--gen go' needs gofmt
+ENV GOLANG_VERSION=1.6
+ENV	GOLANG_DOWNLOAD_URL=https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz \
+	GOLANG_DOWNLOAD_SHA256=5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b
+
 RUN buildDeps=" \
 		automake \
 		bison \
+		ca-certificates \
 		curl \
 		flex \
 		g++ \
@@ -19,19 +25,25 @@ RUN buildDeps=" \
 		libtool \
 		make \
 		pkg-config \
-	"; \
-	apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -sSL "http://apache.mirrors.spacedump.net/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz \
-	&& mkdir -p /usr/src/thrift \
-	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
-	&& rm thrift.tar.gz \
-	&& cd /usr/src/thrift \
-	&& ./configure  --without-python --without-cpp \
-	&& make \
+	" \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& curl -SL "http://apache.mirrors.spacedump.net/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz \
+	&& curl -SL "https://www.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz.asc" -o thrift.tar.gz.asc \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 9782694B8B54B4ADD345E52ABB06368F66B778F9 \
+	&& gpg --verify thrift.tar.gz.asc thrift.tar.gz \
+	&& mkdir -p thrift \
+	&& tar -xzf thrift.tar.gz -C thrift --strip-components=1 \
+	&& rm thrift.tar.gz thrift.tar.gz.asc \
+	&& cd thrift \
+	&& ./configure --without-python --without-cpp \
+	&& make -j"$(nproc)" \
 	&& make install \
-	&& cd / \
-	&& rm -rf /usr/src/thrift \
-	&& curl -k -sSL "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz" -o go.tar.gz \
+	&& cd .. \
+	&& rm -rf thrift \
+	&& curl -SL "$GOLANG_DOWNLOAD_URL" -o go.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA256 go.tar.gz" | sha256sum -c - \
 	&& tar xzf go.tar.gz \
 	&& rm go.tar.gz \
 	&& cp go/bin/gofmt /usr/bin/gofmt \

--- a/0.9/Dockerfile
+++ b/0.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:weezy
+FROM debian:jessie
 MAINTAINER Adam Hawkins <adam@hawkins.io>
 
 ENV THRIFT_VERSION 0.9.3


### PR DESCRIPTION
The original dockerfile works well but does not validate the gpg signature nor verify checksums. This is a very important step since Thrift is used for client-server comms.

I added checks to verify the downloads. A few additional minor edits were done: use jessie, pass make -j flag, use relative paths.
