### PR TITLE
Add support for ARMv8 platform

### DIFF
--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:stretch
 LABEL authors="Adam Hawkins <hi@ahawkins.me>"
 
 ENV THRIFT_VERSION 0.11.0
@@ -31,7 +31,11 @@ RUN buildDeps=" \
 	&& make install \
 	&& cd / \
 	&& rm -rf /usr/src/thrift \
-	&& curl -k -sSL "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz" -o go.tar.gz \
+	&& if [ $(uname -m) = "aarch64" ]; then \
+	curl -k -sSL "https://storage.googleapis.com/golang/go1.10.1.linux-arm64.tar.gz" -o go.tar.gz ; \
+	else \
+	curl -k -sSL "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz" -o go.tar.gz ; \
+	fi \
 	&& tar xzf go.tar.gz \
 	&& rm go.tar.gz \
 	&& cp go/bin/gofmt /usr/bin/gofmt \


### PR DESCRIPTION
The following changes are done to get Thrift working on docker containers running on ARMv8,

a) The wheezy base package doesn't work for arm64, hence moving to latest debian "stretch" package.
b) Download the golang package based on the architecture as they are different for arm64 and amd64