### PR TITLE
Add Thrift 0.12

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -31,11 +31,11 @@ RUN buildDeps=" \
 	&& make install \
 	&& cd / \
 	&& rm -rf /usr/src/thrift \
-	&& curl -k -sSL "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz" -o go.tar.gz \
-	&& tar xzf go.tar.gz \
-	&& rm go.tar.gz \
-	&& cp go/bin/gofmt /usr/bin/gofmt \
-	&& rm -rf go \
-	&& apt-get purge -y --auto-remove $buildDeps
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/cache/apt/* \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /tmp/* \
+	&& rm -rf /var/tmp/*
+
 
 CMD [ "thrift" ]

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:18.04
+
+ENV THRIFT_VERSION v0.12.0
+
+RUN buildDeps=" \
+		automake \
+		bison \
+		curl \
+		flex \
+		g++ \
+		libboost-dev \
+		libboost-filesystem-dev \
+		libboost-program-options-dev \
+		libboost-system-dev \
+		libboost-test-dev \
+		libevent-dev \
+		libssl-dev \
+		libtool \
+		make \
+		pkg-config \
+	"; \
+	apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
+	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& mkdir -p /usr/src/thrift \
+	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
+	&& rm thrift.tar.gz \
+	&& cd /usr/src/thrift \
+	&& ./bootstrap.sh \
+	&& ./configure  --without-python --without-cpp \
+	&& make \
+	&& make install \
+	&& cd / \
+	&& rm -rf /usr/src/thrift \
+	&& curl -k -sSL "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz" -o go.tar.gz \
+	&& tar xzf go.tar.gz \
+	&& rm go.tar.gz \
+	&& cp go/bin/gofmt /usr/bin/gofmt \
+	&& rm -rf go \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+CMD [ "thrift" ]

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -26,7 +26,7 @@ RUN buildDeps=" \
 	&& rm thrift.tar.gz \
 	&& cd /usr/src/thrift \
 	&& ./bootstrap.sh \
-	&& ./configure  --without-python --without-cpp \
+	&& ./configure --disable-libs \
 	&& make \
 	&& make install \
 	&& cd / \


### PR DESCRIPTION
## Overview

- Bump version to 0.12.0
- Fetch source file from github.com
- Use base image "ubuntu:18.04"

----
Resolve #17  