### PR TITLE
Added Dockerfile for Thrift 0.12

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:buster
+LABEL authors="Adam Hawkins <hi@ahawkins.me>"
+
+ENV THRIFT_VERSION 0.12.0
+
+RUN buildDeps=" \
+		automake \
+		bison \
+		curl \
+		flex \
+		g++ \
+		libboost-dev \
+		libboost-filesystem-dev \
+		libboost-program-options-dev \
+		libboost-system-dev \
+		libboost-test-dev \
+		libevent-dev \
+		libssl-dev \
+		libtool \
+		make \
+		pkg-config \
+	"; \
+	apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
+	&& curl -sSL "http://apache.mirrors.spacedump.net/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz \
+	&& mkdir -p /usr/src/thrift \
+	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
+	&& rm thrift.tar.gz \
+	&& cd /usr/src/thrift \
+	&& ./configure  --without-python --without-cpp \
+	&& make \
+	&& make install \
+	&& cd / \
+	&& rm -rf /usr/src/thrift \
+	&& curl -k -sSL "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz" -o go.tar.gz \
+	&& tar xzf go.tar.gz \
+	&& rm go.tar.gz \
+	&& cp go/bin/gofmt /usr/bin/gofmt \
+	&& rm -rf go \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+CMD [ "thrift" ]


### PR DESCRIPTION
Resolves #17 

This PR basically copies the contents of 0.11 to 0.12, changing the Thrift version *and* the Debian base image to `buster` (the latest recommended one, from what I can see).

This has been locally tested with a build of the [Jaeger Java Client](https://github.com/jaegertracing/jaeger-client-java), which uses the Docker image to generate the Java classes based on IDLs.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>