### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,26 @@ Read more about [Thrift](https://thrift.apache.org).
 
 # How To Use This Image
 
-This is image is intended to run as an executable. Files are provided
-by mounting a directory. Here's an example of compiling
-`service.thrift` to ruby.
+This image provides a linux-based thrift compiler for generating runtime code
+from `.thrift` files.  Files are provided to the compiler by mounting
+a directory into the container.  Here's an example of compiling 
+`service.thrift` for Ruby:
 
-    docker run -v "$(pwd):/data" ahawkins/thrift thrift --gen rb /data/service.thrift
+    docker run --rm -v "$(pwd):/data" -w "/data" ahawkins/thrift thrift --gen rb service.thrift
 
-# Language Specific Installations
+This image does not provide any thrift runtime libraries.  To use
+the generated code you will need to set up a language runtime environment
+and install the thrift runtime for that language.  The best way to do this
+is to create your own Dockerfile that starts with this image and then
+add your own content.
 
-Thrift generates code for many lanuages. Some languages have
-additional things to install besides the thrift compiler. They are
-listed below:
+For reference, the 
+[Apache Thrift CI Dockerfile](https://github.com/apache/thrift/blob/master/build/docker/ubuntu-bionic/Dockerfile)
+builds a docker container that contains runtime environments for all of the
+languages that thrift supports.  That image is used when building Apache Thrift.
 
-* Go - `go fmt` from go 1.4
+# For Windows Users
+
+The thrift project provides a Docker for Windows based 
+[Dockerfile](https://github.com/apache/thrift/tree/master/build/docker/msvc2017)
+that can be used to build the thrift compiler on Windows.


### PR DESCRIPTION
The information about go 1.4 in the README is stale.  I refreshed the README for the common use case.