### PR TITLE
Added support for thrift 0.14

### DIFF
--- a/0.14/Dockerfile
+++ b/0.14/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:18.04
+
+ENV THRIFT_VERSION v0.14.0
+
+RUN buildDeps=" \
+		automake \
+		bison \
+		curl \
+		flex \
+		g++ \
+		libboost-dev \
+		libboost-filesystem-dev \
+		libboost-program-options-dev \
+		libboost-system-dev \
+		libboost-test-dev \
+		libevent-dev \
+		libssl-dev \
+		libtool \
+		make \
+		pkg-config \
+	"; \
+	apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
+	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& mkdir -p /usr/src/thrift \
+	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
+	&& rm thrift.tar.gz \
+	&& cd /usr/src/thrift \
+	&& ./bootstrap.sh \
+	&& ./configure --disable-libs \
+	&& make \
+	&& make install \
+	&& cd / \
+	&& rm -rf /usr/src/thrift \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/cache/apt/* \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /tmp/* \
+	&& rm -rf /var/tmp/*
+
+WORKDIR "/data"
+CMD [ "thrift" ]


### PR DESCRIPTION
This is basically the same as the existing 0.12 Dockerfile with 2 differences:

1. Pull 0.14 :)
2. Set /data as the workdir to make it easy to use as a drop-in replacement for a local thrift executable (i.e calling ` docker run -v $(pwd):/data ahawkins/thrift thrift` instead of `thrift`)