### PR TITLE
Build Thrift Docker image with Github Action workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: 0.16/Dockerfile
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/thrift:latest,${{ secrets.DOCKERHUB_USERNAME }}/thrift:0.16.0

--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:22.04
+
+ENV THRIFT_VERSION v0.16.0
+
+RUN buildDeps=" \
+		automake \
+		bison \
+		curl \
+		flex \
+		g++ \
+		libboost-dev \
+		libboost-filesystem-dev \
+		libboost-program-options-dev \
+		libboost-system-dev \
+		libboost-test-dev \
+		libevent-dev \
+		libssl-dev \
+		libtool \
+		make \
+		pkg-config \
+	"; \
+	apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
+	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& mkdir -p /usr/src/thrift \
+	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
+	&& rm thrift.tar.gz \
+	&& cd /usr/src/thrift \
+	&& ./bootstrap.sh \
+	&& ./configure --disable-libs \
+	&& make \
+	&& make install \
+	&& cd / \
+	&& rm -rf /usr/src/thrift \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/cache/apt/* \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /tmp/* \
+	&& rm -rf /var/tmp/*
+
+
+CMD [ "thrift" ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ This is image is intended to run as an executable. Files are provided
 by mounting a directory. Here's an example of compiling
 `service.thrift` to ruby.
 
-    docker run -v "$(pwd):/data" ahawkins/thrift thrift --gen rb /data/service.thrift
+```bash
+docker run -v "$(pwd):/data" ahawkins/thrift thrift --gen rb /data/service.thrift
+```
+
+# How To Build This Image
+
+```bash
+docker build -f 0.16/Dockerfile -t ahawkins/thrift:0.16.0
+```
 
 # Language Specific Installations
 


### PR DESCRIPTION
Depends on https://github.com/ahawkins/docker-thrift/pull/26